### PR TITLE
README FIX: persist-credentials defaults to `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ jobs:
     ssh-strict: ''
 
     # Whether to configure the token or SSH key with the local git config
-    # Default: true
+    # Default: false
     persist-credentials: ''
 
     # Includes your name to the commit


### PR DESCRIPTION
`persist-credentials` actually defaults to `false` according to the code:
https://github.com/narrowspark/template-sync-action/blob/fd6ad0da91a3890d35eb3faa4f161726281d252b/src/settings.ts#L32

| Q             | A
| ------------- | ---
| Branch?       | master   <!-- for features -->
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no   <!-- don't forget to update UPGRADE-*.md file(s) -->
| Tickets       | Fix #... <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT
| Doc PR        | no

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass.
 - Never break backward compatibility
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the branch "master".
 - Legacy code removals go to the master branch.
-->